### PR TITLE
Small tweaks to make scripts work for us

### DIFF
--- a/scripts/fixup-bosh-lite-vms.bash
+++ b/scripts/fixup-bosh-lite-vms.bash
@@ -16,12 +16,12 @@ THIS_DIR=$(dirname $(abspath $0))
 
 . $THIS_DIR/shell_helpers.bash
 
-OUR_BOSH_LITES=$($THIS_DIR/aws-running-vms.bash| grep $BOSH_LITE_AMI | pcut -f -2 | nl2comma)
-echo "our bosh-lite VMs are $OUR_BOSH_LITES"
-
 # add host keys
-our_boshlites 1 ; parallel -j 50 "ssh -o StrictHostKeyChecking=no ubuntu@{} id" ::: $OUR_BOSHLITES
+our_boshlites 1 
+echo "our bosh-lite VMs are $OUR_BOSHLITES"
+parallel -j 50 "ssh -o StrictHostKeyChecking=no ubuntu@{} id" ::: $OUR_BOSHLITES
+echo parallel -j 50 "ssh -o StrictHostKeyChecking=no ubuntu@{} id" ::: $OUR_BOSHLITES
 
 
 chmod 755 $THIS_DIR/jsh_bosh-lite-box-prep.bash
-jsh -e -w $OUR_BOSH_LITES -l ubuntu -s $THIS_DIR/jsh_bosh-lite-box-prep.bash
+jsh -e -w $OUR_BOSHLITES_JSH -l ubuntu -s $THIS_DIR/jsh_bosh-lite-box-prep.bash

--- a/scripts/shell_helpers.bash
+++ b/scripts/shell_helpers.bash
@@ -4,9 +4,9 @@ ssh-add $HOME/workspace/deployments-aws/thansmann/config/id_rsa_bosh
 
 function our_boshlites() {
     if [[ ! -z "$*" || -z "$OUR_BOSHLITES" ]]; then
-        export OUR_BOSHLITES=$(aws-running-vms.bash | pcut -f -2)
-    fi
-    OUR_BOSHLITES_JSH=$(echo $OUR_BOSHLITES|space2comma)
+        export OUR_BOSHLITES=$(aws-running-vms.bash | cut -d ' ' -f6)
+      fi
+    export OUR_BOSHLITES_JSH=$(echo $OUR_BOSHLITES | tr ' ' ',')
     echo $OUR_BOSHLITES
 }
 

--- a/scripts/terminate_aws_bosh_lite_vms.bash
+++ b/scripts/terminate_aws_bosh_lite_vms.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-aws ec2 describe-instances --output text | tr '   ' ' ' | egrep  'INSTANCES\b|STATE\b' | paste - - | grep running|  awk '{print $8}' |
-  parallel -j30 -rt "aws ec2 terminate-instances --instance-ids {}"
+aws ec2 describe-instances --output text | tr '   ' ' ' | egrep  'INSTANCES\b|STATE\b' | paste - - | grep running |  awk '{print $7}' |
+ parallel -j30 -rt "aws ec2 terminate-instances --instance-ids {}"
 


### PR DESCRIPTION
- needed to export OUR_BOSHLITES_JSH and use it with jsh
- avoid pcut, space2comma and nl2comma in favor of more common tr and cut (to avoid depending on basic-env scripts)
- remove a tiny amount of duplication